### PR TITLE
Fix for issue #6 and one other error

### DIFF
--- a/mailproxy.py
+++ b/mailproxy.py
@@ -39,10 +39,9 @@ class MailProxyHandler:
         refused = {}
         try:
             if self._use_ssl:
-                s = smtplib.SMTP_SSL()
+                s = smtplib.SMTP_SSL(self._host, self._port)
             else:
-                s = smtplib.SMTP()
-            s.connect(self._host, self._port)
+                s = smtplib.SMTP(self._host, self._port)
             if self._starttls:
                 s.starttls()
                 s.ehlo()

--- a/mailproxy.py
+++ b/mailproxy.py
@@ -61,7 +61,7 @@ class MailProxyHandler:
             # All recipients were refused. If the exception had an associated
             # error code, use it.  Otherwise, fake it with a SMTP 554 status code. 
             errcode = getattr(e, 'smtp_code', 554)
-            errmsg = getattr(e, 'smtp_error', e.__class__)
+            errmsg = getattr(e, 'smtp_error', e.__class__.__name__.encode())
             raise smtplib.SMTPResponseException(errcode, errmsg.decode())
 
 

--- a/mailproxy.py
+++ b/mailproxy.py
@@ -54,7 +54,10 @@ class MailProxyHandler:
                     envelope.original_content
                 )
             finally:
-                s.quit()
+                try:
+                    s.quit()
+                except smtplib.SMTPServerDisconnected:
+                    pass
         except (OSError, smtplib.SMTPException) as e:
             logging.exception('got %s', e.__class__)
             # All recipients were refused. If the exception had an associated


### PR DESCRIPTION
If delivery failed due to a SMTPNotSupportedError exception, the
exception handler in _deliver would try to invoke the decode() method
on the class object, resulting in a cascading error.  This commit
fixes that problem.